### PR TITLE
use parseLog on testing events

### DIFF
--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -350,7 +350,7 @@ describe("Bridge", function () {
       expect(issuerResult[3]).to.equal(statuses.COMPLETED);
     });
 
-    it.only("checks that Issuance Completed is emitted properly", async () => {
+    it("checks that Issuance Completed is emitted properly", async () => {
       await bridge.createIssuer(issuer, AMOUNT_TO_ISSUE);
       const tx = await bridge.completeIssuance(
         txHash,


### PR DESCRIPTION
fixes #81 

@mrosendin Can you try the pattern in this commit? that's how i usually parse the events, the result will look something like this.

```
LogDescription {
    eventFragment: EventFragment {
      name: 'IssuanceCompleted',
      anonymous: false,
      inputs: [Array],
      type: 'event',
      _isFragment: true,
      constructor: [Function],
      format: [Function]
    },
    name: 'IssuanceCompleted',
    signature: 'IssuanceCompleted(string,uint256)',
    topic: '0x987450b6d8223519827c185326f867b4cc0fe1c9496871a7691cb641bbde7839',
    args: [
      'rDfB33LHNMmWSUHoXUd2pj1oJxsDZ7e2dn',
      [BigNumber],
      issuer: 'rDfB33LHNMmWSUHoXUd2pj1oJxsDZ7e2dn',
      amount: [BigNumber]
    ]
  }

```