### PR TITLE
IOUs -> Shares

### DIFF
--- a/contracts/mocks/MockReservePool.sol
+++ b/contracts/mocks/MockReservePool.sol
@@ -8,17 +8,17 @@ contract MockReservePool {
 
     LastShutdownRedemptionCall public lastRedemptionCall;
     mapping(bytes32 => bool) public states;
-    mapping(address => uint256) public ious;
-    uint256 public totalIous;
+    mapping(address => uint256) public shares;
+    uint256 public totalShares;
     uint256 public lastReduceAuctionDebtAmount;
     uint256 public lastAddAuctionDebtAmount;
 
-    function setIous(address user, uint256 amount) external {
-        ious[user] = amount;
+    function setShares(address user, uint256 amount) external {
+        shares[user] = amount;
     }
 
-    function setTotalIous(uint256 newTotal) external {
-        totalIous = newTotal;
+    function setTotalShares(uint256 newTotal) external {
+        totalShares = newTotal;
     }
 
     function shutdownRedemption(address user, uint256 amount) external {

--- a/contracts/probity/Shutdown.sol
+++ b/contracts/probity/Shutdown.sol
@@ -83,9 +83,9 @@ interface VaultLike {
 }
 
 interface ReservePoolLike {
-    function ious(address user) external returns (uint256 balance);
+    function shares(address user) external returns (uint256 balance);
 
-    function totalIous() external returns (uint256);
+    function totalShares() external returns (uint256);
 
     function shutdownRedemption(address user, uint256 amount) external;
 
@@ -421,7 +421,7 @@ contract Shutdown is Stateful, Eventful {
     }
 
     function setFinalSystemReserve() external {
-        require(finalDebtBalance != 0, "shutdown/redeemIou: finalDebtBalance must be set first");
+        require(finalDebtBalance != 0, "shutdown/redeemShares: finalDebtBalance must be set first");
 
         uint256 totalSystemReserve = vaultEngine.stablecoin(address(reservePool));
         require(totalSystemReserve != 0, "shutdown/setFinalSystemReserve: system reserve is zero");
@@ -429,19 +429,19 @@ contract Shutdown is Stateful, Eventful {
         finalTotalReserve = totalSystemReserve;
     }
 
-    function redeemIou() external {
-        require(finalTotalReserve != 0, "shutdown/redeemIou: finalTotalReserve must be set first");
+    function redeemShares() external {
+        require(finalTotalReserve != 0, "shutdown/redeemShares: finalTotalReserve must be set first");
 
-        uint256 userIouBalance = reservePool.ious(msg.sender);
-        uint256 totalIouBalance = reservePool.totalIous();
+        uint256 userShares = reservePool.shares(msg.sender);
+        uint256 totalShares = reservePool.totalShares();
 
-        require(userIouBalance != 0 && totalIouBalance != 0, "shutdown/redeemIou: no iou to redeem");
+        require(userShares != 0 && totalShares != 0, "shutdown/redeemShares: no shares to redeem");
 
-        uint256 percentageOfIous = rdiv(userIouBalance, totalIouBalance);
+        uint256 percentageOfIous = rdiv(userShares, totalShares);
         uint256 shareOfAur = rmul(percentageOfIous, finalTotalReserve);
 
-        if (shareOfAur > userIouBalance) {
-            shareOfAur = userIouBalance;
+        if (shareOfAur > userShares) {
+            shareOfAur = userShares;
         }
 
         reservePool.shutdownRedemption(msg.sender, shareOfAur);

--- a/test/happyFlow.test.ts
+++ b/test/happyFlow.test.ts
@@ -539,14 +539,14 @@ describe("Probity happy flow", function () {
 
     await liquidator.reduceAuctionDebt(PRECISION_AUR.mul(201));
     await reserve.connect(gov).updateDebtThreshold(PRECISION_AUR.mul(200));
-    await reserve.startIouSale();
+    await reserve.startSale();
 
     const reserveUser = reserve.connect(user);
     await ethers.provider.send("evm_increaseTime", [21601]);
     await ethers.provider.send("evm_mine", []);
-    await reserveUser.buyIou(PRECISION_AUR.mul(100));
+    await reserveUser.purchaseShares(PRECISION_AUR.mul(100));
 
-    let userIOU = await reserve.ious(user.address);
+    let userIOU = await reserve.shares(user.address);
     expect(userIOU > PRECISION_AUR.mul(100)).to.equal(true);
   });
 });

--- a/test/probity/shutdown.test.ts
+++ b/test/probity/shutdown.test.ts
@@ -1084,7 +1084,7 @@ describe("Shutdown Unit Tests", function () {
     });
   });
 
-  describe("redeemIou Unit Tests", function () {
+  describe("redeemShares Unit Tests", function () {
     const TOTAL_DEBT_TO_SET = PRECISION_AUR.mul(150);
 
     beforeEach(async function () {
@@ -1094,7 +1094,7 @@ describe("Shutdown Unit Tests", function () {
       await increaseTime(172800 * 2);
       await increaseTime(172800);
       await shutdown.setFinalDebtBalance();
-      await reservePool.setTotalIous(PRECISION_AUR);
+      await reservePool.setTotalShares(PRECISION_AUR);
       await vaultEngine.setStablecoin(
         reservePool.address,
         PRECISION_AUR.mul(1000)
@@ -1102,38 +1102,38 @@ describe("Shutdown Unit Tests", function () {
     });
 
     it("fails if finalTotalReserve is not set", async () => {
-      await reservePool.setIous(owner.address, PRECISION_AUR);
+      await reservePool.setShares(owner.address, PRECISION_AUR);
       await assertRevert(
-        shutdown.redeemIou(),
-        "shutdown/redeemIou: finalTotalReserve must be set first"
+        shutdown.redeemShares(),
+        "shutdown/redeemShares: finalTotalReserve must be set first"
       );
       await shutdown.setFinalSystemReserve();
 
-      await shutdown.redeemIou();
+      await shutdown.redeemShares();
     });
 
-    it("fails if user's IOU balance is zero", async () => {
+    it("fails if user's amount of shares is zero", async () => {
       await shutdown.setFinalSystemReserve();
 
       await assertRevert(
-        shutdown.redeemIou(),
-        "shutdown/redeemIou: no iou to redeem"
+        shutdown.redeemShares(),
+        "shutdown/redeemShares: no shares to redeem"
       );
-      await reservePool.setIous(owner.address, PRECISION_AUR);
-      await shutdown.redeemIou();
+      await reservePool.setShares(owner.address, PRECISION_AUR);
+      await shutdown.redeemShares();
     });
 
-    it("fails if total IOU balance is zero", async () => {
+    it("fails if total shares are zero", async () => {
       await shutdown.setFinalSystemReserve();
-      await reservePool.setIous(owner.address, PRECISION_AUR);
-      await reservePool.setTotalIous(0);
+      await reservePool.setShares(owner.address, PRECISION_AUR);
+      await reservePool.setTotalShares(0);
 
       await assertRevert(
-        shutdown.redeemIou(),
-        "shutdown/redeemIou: no iou to redeem"
+        shutdown.redeemShares(),
+        "shutdown/redeemShares: no shares to redeem"
       );
-      await reservePool.setTotalIous(PRECISION_AUR);
-      await shutdown.redeemIou();
+      await reservePool.setTotalShares(PRECISION_AUR);
+      await shutdown.redeemShares();
     });
 
     it("tests that shutdownRedemption is called with correct parameter", async () => {
@@ -1148,10 +1148,10 @@ describe("Shutdown Unit Tests", function () {
         rdiv(USER_IOU, TOTAL_IOU),
         finalTotalReserve
       );
-      await reservePool.setIous(owner.address, USER_IOU);
-      await reservePool.setTotalIous(TOTAL_IOU);
+      await reservePool.setShares(owner.address, USER_IOU);
+      await reservePool.setTotalShares(TOTAL_IOU);
 
-      await shutdown.redeemIou();
+      await shutdown.redeemShares();
 
       const lastCall = await reservePool.lastRedemptionCall();
       expect(lastCall.user).to.equal(owner.address);

--- a/test/shutdownFlow.test.ts
+++ b/test/shutdownFlow.test.ts
@@ -360,8 +360,8 @@ describe("Shutdown Flow Test", function () {
     );
     await expectBalancesToMatch(user2, balances.user2);
 
-    await reserve.startIouSale();
-    await reserve.connect(user3).buyIou(DEBT_THRESHOLD.mul(3).div(4));
+    await reserve.startSale();
+    await reserve.connect(user3).purchaseShares(DEBT_THRESHOLD.mul(3).div(4));
     reserveBalances.debt = reserveBalances.debt.sub(
       DEBT_THRESHOLD.mul(3).div(4)
     );
@@ -372,7 +372,7 @@ describe("Shutdown Flow Test", function () {
     );
     await expectBalancesToMatch(user3, balances.user3);
 
-    await reserve.connect(user2).buyIou(DEBT_THRESHOLD.div(4));
+    await reserve.connect(user2).purchaseShares(DEBT_THRESHOLD.div(4));
     reserveBalances.debt = reserveBalances.debt.sub(DEBT_THRESHOLD.div(4));
     await checkReserveBalances(reserveBalances);
 
@@ -584,9 +584,9 @@ describe("Shutdown Flow Test", function () {
         .lte(PRECISION_AUR.div(100))
     ).to.equal(true);
 
-    before = await reserve.ious(user2.address);
-    await shutdown.connect(user2).redeemIou();
-    after = await reserve.ious(user2.address);
+    before = await reserve.shares(user2.address);
+    await shutdown.connect(user2).redeemShares();
+    after = await reserve.shares(user2.address);
     const EXPECTED_IOU_BALANCE_CHANGE = DEBT_THRESHOLD.div(4);
     expect(before.sub(after)).to.equal(EXPECTED_IOU_BALANCE_CHANGE);
   });


### PR DESCRIPTION
New naming convention for what were called IOUs:

I was wrong about calling them "bonds", even though a zero-coupon bond with no maturity is a pretty good description, calling them `bonds` would be misleading, and calling them `shares`, as in shares in the reserve pool profits, makes more sense.

For https://github.com/trustline-inc/probity/issues/120, I recommend we call the new contract `ReservePoolOffering`