### PR TITLE
use initialEquity over normalized equity in `certify`

### DIFF
--- a/contracts/probity/VaultEngine.sol
+++ b/contracts/probity/VaultEngine.sol
@@ -428,7 +428,7 @@ contract VaultEngine is Stateful, Eventful {
      */
     function certify(bytes32 assetId, Vault memory vault) internal view {
         require(
-            (vault.debt * assets[assetId].debtAccumulator) + (vault.equity * RAY) <=
+            (vault.debt * assets[assetId].debtAccumulator) + vault.initialEquity <=
                 vault.activeAssetAmount * assets[assetId].adjustedPrice,
             "Vault/certify: Not enough underlying/collateral"
         );


### PR DESCRIPTION
this will solve the issue when the accumulator is above RAY and vault is undercollateralized