### PR TITLE
using mul over div to prevent loss of precision

### DIFF
--- a/contracts/probity/VaultEngine.sol
+++ b/contracts/probity/VaultEngine.sol
@@ -212,13 +212,13 @@ contract VaultEngine is Stateful, Eventful {
         Vault storage vault = vaults[assetId][msg.sender];
         vault.standbyAssetAmount = sub(vault.standbyAssetAmount, underlyingAmount);
         vault.activeAssetAmount = add(vault.activeAssetAmount, underlyingAmount);
-        int256 normalizedEquity = div(equityAmount, assets[assetId].equityAccumulator);
-        vault.equity = add(vault.equity, normalizedEquity);
-        vault.initialEquity = add(vault.initialEquity, equityAmount);
+        int256 equityCreated = mul(assets[assetId].equityAccumulator, equityAmount);
+        vault.equity = add(vault.equity, equityAmount);
+        vault.initialEquity = add(vault.initialEquity, equityCreated);
 
-        assets[assetId].normEquity = add(assets[assetId].normEquity, normalizedEquity);
+        assets[assetId].normEquity = add(assets[assetId].normEquity, equityAmount);
 
-        totalEquity = add(totalEquity, equityAmount);
+        totalEquity = add(totalEquity, equityCreated);
 
         require(totalEquity <= assets[assetId].ceiling, "Vault/modifyEquity: Supply ceiling reached");
         require(
@@ -227,9 +227,9 @@ contract VaultEngine is Stateful, Eventful {
         );
         certify(assetId, vault);
 
-        stablecoin[treasuryAddress] = add(stablecoin[treasuryAddress], equityAmount);
+        stablecoin[treasuryAddress] = add(stablecoin[treasuryAddress], equityCreated);
 
-        emit EquityModified(msg.sender, underlyingAmount, equityAmount);
+        emit EquityModified(msg.sender, underlyingAmount, equityCreated);
     }
 
     /**
@@ -262,12 +262,12 @@ contract VaultEngine is Stateful, Eventful {
         Vault memory vault = vaults[assetId][msg.sender];
         vault.standbyAssetAmount = sub(vault.standbyAssetAmount, collAmount);
         vault.activeAssetAmount = add(vault.activeAssetAmount, collAmount);
-        int256 normalizedDebt = div(debtAmount, assets[assetId].debtAccumulator);
-        vault.debt = add(vault.debt, normalizedDebt);
+        int256 debtCreated = mul(assets[assetId].debtAccumulator, debtAmount);
+        vault.debt = add(vault.debt, debtAmount);
 
-        assets[assetId].normDebt = add(assets[assetId].normDebt, normalizedDebt);
+        assets[assetId].normDebt = add(assets[assetId].normDebt, debtAmount);
 
-        totalDebt = add(totalDebt, debtAmount);
+        totalDebt = add(totalDebt, debtCreated);
 
         require(totalDebt <= assets[assetId].ceiling, "Vault/modifyDebt: Debt ceiling reached");
         require(
@@ -276,12 +276,12 @@ contract VaultEngine is Stateful, Eventful {
         );
         certify(assetId, vault);
 
-        stablecoin[msg.sender] = add(stablecoin[msg.sender], debtAmount);
-        stablecoin[treasuryAddress] = sub(stablecoin[treasuryAddress], debtAmount);
+        stablecoin[msg.sender] = add(stablecoin[msg.sender], debtCreated);
+        stablecoin[treasuryAddress] = sub(stablecoin[treasuryAddress], debtCreated);
 
         vaults[assetId][msg.sender] = vault;
 
-        emit DebtModified(msg.sender, collAmount, debtAmount);
+        emit DebtModified(msg.sender, collAmount, debtCreated);
     }
 
     /**

--- a/test/happyFlow.test.ts
+++ b/test/happyFlow.test.ts
@@ -54,12 +54,12 @@ const RAD = ethers.BigNumber.from(
 const ASSET_AMOUNT = WAD.mul(1000);
 const UNDERLYING_AMOUNT = WAD.mul(400);
 const UNDERLYING_AMOUNT_TO_DECREASE = WAD.mul(-400);
-const EQUITY_AMOUNT_TO_DECREASE = RAD.mul(-200);
-const EQUITY_AMOUNT = RAD.mul(200);
+const EQUITY_AMOUNT_TO_DECREASE = WAD.mul(-200);
+const EQUITY_AMOUNT = WAD.mul(200);
 const COLL_AMOUNT = WAD.mul(200);
-const LOAN_AMOUNT = RAD.mul(100);
+const LOAN_AMOUNT = WAD.mul(100);
 const LOAN_REPAY_COLL_AMOUNT = WAD.mul(-200);
-const LOAN_REPAY_AMOUNT = RAD.mul(-100);
+const LOAN_REPAY_AMOUNT = WAD.mul(-100);
 
 const flrAssetId = web3.utils.keccak256("FLR");
 const fxrpAssetId = web3.utils.keccak256("FXRP");
@@ -187,9 +187,7 @@ describe("Probity happy flow", function () {
     expect(userVaultBefore[0].sub(userVaultAfter[0])).to.equal(
       UNDERLYING_AMOUNT
     );
-    expect(userVaultAfter[3].sub(userVaultBefore[3])).to.equal(
-      EQUITY_AMOUNT.div(RAY)
-    );
+    expect(userVaultAfter[3].sub(userVaultBefore[3])).to.equal(EQUITY_AMOUNT);
 
     userVaultBefore = await vaultEngine.vaults(flrAssetId, owner.address);
     let aurBefore = await vaultEngine.stablecoin(owner.address);
@@ -203,12 +201,10 @@ describe("Probity happy flow", function () {
     );
 
     let aurAfter = await vaultEngine.stablecoin(owner.address);
-    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_AMOUNT);
+    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_AMOUNT.mul(RAY));
     userVaultAfter = await vaultEngine.vaults(flrAssetId, owner.address);
     expect(userVaultBefore[0].sub(userVaultAfter[0])).to.equal(COLL_AMOUNT);
-    expect(userVaultAfter[2].sub(userVaultBefore[2])).to.equal(
-      LOAN_AMOUNT.div(RAY)
-    );
+    expect(userVaultAfter[2].sub(userVaultBefore[2])).to.equal(LOAN_AMOUNT);
 
     // Stablecoin withdrawal
     let ownerBalanceBefore = await aurei.balanceOf(owner.address);
@@ -252,12 +248,10 @@ describe("Probity happy flow", function () {
     );
 
     let aurAfter = await vaultEngine.stablecoin(owner.address);
-    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_AMOUNT);
+    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_AMOUNT.mul(RAY));
     let userVaultAfter = await vaultEngine.vaults(flrAssetId, owner.address);
     expect(userVaultBefore[0].sub(userVaultAfter[0])).to.equal(COLL_AMOUNT);
-    expect(userVaultAfter[2].sub(userVaultBefore[2])).to.equal(
-      LOAN_AMOUNT.div(RAY)
-    );
+    expect(userVaultAfter[2].sub(userVaultBefore[2])).to.equal(LOAN_AMOUNT);
 
     userVaultBefore = await vaultEngine.vaults(flrAssetId, owner.address);
     aurBefore = await vaultEngine.stablecoin(owner.address);
@@ -271,13 +265,13 @@ describe("Probity happy flow", function () {
     );
 
     aurAfter = await vaultEngine.stablecoin(owner.address);
-    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_REPAY_AMOUNT);
+    expect(aurAfter.sub(aurBefore)).to.equal(LOAN_REPAY_AMOUNT.mul(RAY));
     userVaultAfter = await vaultEngine.vaults(flrAssetId, owner.address);
     expect(userVaultBefore[0].sub(userVaultAfter[0])).to.equal(
       LOAN_REPAY_COLL_AMOUNT
     );
     expect(userVaultAfter[2].sub(userVaultBefore[2])).to.equal(
-      LOAN_REPAY_AMOUNT.div(RAY)
+      LOAN_REPAY_AMOUNT
     );
   });
 
@@ -308,9 +302,7 @@ describe("Probity happy flow", function () {
     expect(userVaultBefore[0].sub(userVaultAfter[0])).to.equal(
       UNDERLYING_AMOUNT
     );
-    expect(userVaultAfter[3].sub(userVaultBefore[3])).to.equal(
-      EQUITY_AMOUNT.div(RAY)
-    );
+    expect(userVaultAfter[3].sub(userVaultBefore[3])).to.equal(EQUITY_AMOUNT);
 
     // Redeem underlying assets
     await vaultEngine.modifyEquity(
@@ -328,7 +320,7 @@ describe("Probity happy flow", function () {
       UNDERLYING_AMOUNT_TO_DECREASE
     );
     expect(userVaultAfterDecrease[3].sub(userVaultAfter[3])).to.equal(
-      EQUITY_AMOUNT_TO_DECREASE.div(RAY)
+      EQUITY_AMOUNT_TO_DECREASE
     );
   });
 
@@ -383,7 +375,7 @@ describe("Probity happy flow", function () {
     let unBackedAurAfter = await vaultEngine.unbackedDebt(reserve.address);
     let userVaultAfter = await vaultEngine.vaults(flrAssetId, owner.address);
     expect(unBackedAurAfter.sub(unBackedAurBefore)).to.equal(
-      EQUITY_AMOUNT.add(LOAN_AMOUNT)
+      EQUITY_AMOUNT.add(LOAN_AMOUNT).mul(RAY)
     );
     expect(userVaultBefore[1].sub(userVaultAfter[1])).to.equal(
       UNDERLYING_AMOUNT.add(COLL_AMOUNT)
@@ -428,13 +420,13 @@ describe("Probity happy flow", function () {
       flrAssetId,
       treasury.address,
       WAD.mul(20000),
-      RAD.mul(1000)
+      WAD.mul(1000)
     );
     await vaultUser.modifyDebt(
       flrAssetId,
       treasury.address,
       WAD.mul(900),
-      RAD.mul(600)
+      WAD.mul(600)
     );
 
     await auctioneerUser.placeBid(0, RAY.mul(11).div(10), WAD.mul("100"));
@@ -498,14 +490,14 @@ describe("Probity happy flow", function () {
       flrAssetId,
       treasury.address,
       WAD.mul(20000),
-      RAD.mul(1000)
+      WAD.mul(1000)
     );
 
     await vaultUser.modifyDebt(
       flrAssetId,
       treasury.address,
       WAD.mul(900),
-      RAD.mul(600)
+      WAD.mul(600)
     );
 
     await liquidator.reduceAuctionDebt(RAD.mul(201));

--- a/test/shutdownFlow.test.ts
+++ b/test/shutdownFlow.test.ts
@@ -230,7 +230,7 @@ describe("Shutdown Flow Test", function () {
       .deposit({ value: ethers.utils.parseEther("2300") });
     await vaultEngine
       .connect(user1)
-      .modifyEquity(flrAssetId, treasury.address, WAD.mul(2300), RAD.mul(1000));
+      .modifyEquity(flrAssetId, treasury.address, WAD.mul(2300), WAD.mul(1000));
     balances.user1.flr = {
       activeAmount: WAD.mul(2300),
       equity: WAD.mul(1000),
@@ -243,7 +243,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(1_000_000),
-        RAD.mul(300_000)
+        WAD.mul(300_000)
       );
     balances.user1.fxrp = {
       activeAmount: WAD.mul(1_000_000),
@@ -258,7 +258,7 @@ describe("Shutdown Flow Test", function () {
     await fxrpDeposit(user2, WAD.mul(270000));
     await vaultEngine
       .connect(user2)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(2300), RAD.mul(1500));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(2300), WAD.mul(1500));
     balances.user2.flr = {
       activeAmount: WAD.mul(2300),
       debt: WAD.mul(1500),
@@ -271,7 +271,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(150_000),
-        RAD.mul(135_000)
+        WAD.mul(135_000)
       );
     balances.user2.fxrp = {
       activeAmount: WAD.mul(150_000),
@@ -289,7 +289,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(400_000),
-        RAD.mul(150_000)
+        WAD.mul(150_000)
       );
     // User 3 activates 200_000 FXRP to BORROW 150_000 AUR
     await vaultEngine
@@ -298,7 +298,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(200_000),
-        RAD.mul(150_000)
+        WAD.mul(150_000)
       );
     balances.user3.fxrp = {
       activeAmount: WAD.mul(600_000),
@@ -315,7 +315,7 @@ describe("Shutdown Flow Test", function () {
       .deposit({ value: ethers.utils.parseEther("6900") });
     await vaultEngine
       .connect(user4)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(6900), RAD.mul(4500));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(6900), WAD.mul(4500));
     balances.user4.flr = {
       activeAmount: WAD.mul(6900),
       debt: WAD.mul(4500),
@@ -612,7 +612,7 @@ describe("Shutdown Flow Test", function () {
     await fxrpDeposit(user1, WAD.mul(1000000));
     await vaultEngine
       .connect(user1)
-      .modifyEquity(flrAssetId, treasury.address, WAD.mul(4500), RAD.mul(5000));
+      .modifyEquity(flrAssetId, treasury.address, WAD.mul(4500), WAD.mul(5000));
     balances.user1.flr = {
       activeAmount: WAD.mul(4500),
       equity: WAD.mul(5000),
@@ -624,7 +624,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(1000000),
-        RAD.mul(2000000)
+        WAD.mul(2000000)
       );
     balances.user1.fxrp = {
       activeAmount: WAD.mul(1000000),
@@ -638,7 +638,7 @@ describe("Shutdown Flow Test", function () {
     await fxrpDeposit(user2, WAD.mul(270000));
     await vaultEngine
       .connect(user2)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(2300), RAD.mul(6000));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(2300), WAD.mul(6000));
     balances.user2.flr = {
       activeAmount: WAD.mul(2300),
       debt: WAD.mul(6000),
@@ -649,7 +649,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(270000),
-        RAD.mul(1100000)
+        WAD.mul(1100000)
       );
     balances.user2.fxrp = {
       activeAmount: WAD.mul(270000),
@@ -663,10 +663,10 @@ describe("Shutdown Flow Test", function () {
       .deposit({ value: ethers.utils.parseEther("9000") });
     await vaultEngine
       .connect(user3)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(9000), RAD.mul(15000));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(9000), WAD.mul(15000));
     await vaultEngine
       .connect(user3)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(0), RAD.mul(10000));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(0), WAD.mul(10000));
 
     balances.user3.flr = {
       activeAmount: WAD.mul(9000),
@@ -682,7 +682,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(400000),
-        RAD.mul(1000000)
+        WAD.mul(1000000)
       );
     await vaultEngine
       .connect(user4)
@@ -690,7 +690,7 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(220000),
-        RAD.mul(1500000)
+        WAD.mul(1500000)
       );
 
     balances.user4.fxrp = {
@@ -707,10 +707,10 @@ describe("Shutdown Flow Test", function () {
     await fxrpDeposit(user5, WAD.mul(1830000));
     await vaultEngine
       .connect(user5)
-      .modifyEquity(flrAssetId, treasury.address, WAD.mul(1000), RAD.mul(1500));
+      .modifyEquity(flrAssetId, treasury.address, WAD.mul(1000), WAD.mul(1500));
     await vaultEngine
       .connect(user5)
-      .modifyDebt(flrAssetId, treasury.address, WAD.mul(1000), RAD.mul(1500));
+      .modifyDebt(flrAssetId, treasury.address, WAD.mul(1000), WAD.mul(1500));
 
     balances.user5.flr = {
       activeAmount: WAD.mul(1000 + 1000),
@@ -724,11 +724,11 @@ describe("Shutdown Flow Test", function () {
         fxrpAssetId,
         treasury.address,
         WAD.mul(1830000),
-        RAD.mul(1500000)
+        WAD.mul(1500000)
       );
     await vaultEngine
       .connect(user5)
-      .modifyDebt(fxrpAssetId, treasury.address, WAD.mul(0), RAD.mul(1200000));
+      .modifyDebt(fxrpAssetId, treasury.address, WAD.mul(0), WAD.mul(1200000));
 
     balances.user5.fxrp = {
       activeAmount: WAD.mul(1830000),


### PR DESCRIPTION
ModifyEquity will now expect `equityAmount` in WAD and same goes for ModifyDebt's `debtAmount`

This fixes the following issues

closes #195 
closes #177 