### PR TITLE
Phi: Inflation protection

### DIFF
--- a/contracts/mocks/MockFtso.sol
+++ b/contracts/mocks/MockFtso.sol
@@ -19,13 +19,4 @@ contract MockFtso {
     function getCurrentPrice() external view returns (uint256 _price, uint256 _timestamp) {
         return (price, lastUpdated);
     }
-
-    function setCurrentInflationRate(uint256 _inflationRate) external {
-        inflationRate = _inflationRate;
-        lastUpdated = block.timestamp;
-    }
-
-    function getCurrentInflationRate() external view returns (uint256 _inflationRate, uint256 _timestamp) {
-        return (inflationRate, lastUpdated);
-    }
 }


### PR DESCRIPTION
@shine2lay could use some help finishing this PR. This PR will allow the investor to create Phi when they invest. We still need to mint ERC20 phi as a token. Right now it's just being tracked in the vault engine as the equity balance.

To do:
- [ ] Divide by `Teller.cumulativeInflationRate` in VaultEngine `certifyEquityPosition`
- [ ] Implement a linked list in Teller to track inflation for each month of the past 12 months, and move head/tail when `Teller.updateInflationRate` is called monthly
- [ ] Mint ERC20 phi for investor